### PR TITLE
FEATURE-maindoc-route

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # orphaned-proton
 An HTTP reflector, used for testing.
 
+Github repo: [flightstats/orphaned-proton](https://github.com/flightstats/orphaned-proton)
+
 ## Routes
 
 ## GET /health

--- a/app.js
+++ b/app.js
@@ -2,6 +2,9 @@
 
 var express = require('express');
 var bodyParser = require('body-parser');
+var fs = require('fs');
+var path = require('path');
+var marked = require('marked');
 
 var PORT = '9191';
 
@@ -9,6 +12,15 @@ var app = express();
 app.set('port', PORT);
 app.set('json spaces', 4);
 app.use(bodyParser.urlencoded({extended: true}));
+
+app.get('/', function(req, res) {
+  var path = __dirname + '/README.md';
+  var file = fs.readFile(path, 'utf8', function(err, data) {
+      console.log(err);
+    }
+    res.send(marked(data.toString()));
+  });
+});
 
 app.get('/status/:responseStatus', (req, res) => {
     res.status(req.params.responseStatus);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/flightstats/orphaned-proton#readme",
   "dependencies": {
     "body-parser": "^1.14.1",
-    "express": "^4.13.3"
+    "express": "^4.13.3",
+    "marked": "^0.3.5"
   }
 }


### PR DESCRIPTION
Add a render of the readme.md as the main / route. This allows for the rendering of the README.md as documentation for the microservice in an elegant and async way.
